### PR TITLE
bugfix on tools

### DIFF
--- a/p_winds/tools.py
+++ b/p_winds/tools.py
@@ -28,12 +28,7 @@ def nearest_index(array, target_value):
     index (``int``):
         Index of the value in ``array`` that is closest to ``target_value``.
     """
-    index = array.searchsorted(target_value)
-    index = np.clip(index, 1, len(array) - 1)
-    left = array[index - 1]
-    right = array[index]
-    index -= target_value - left < right - target_value
-    return index
+    return np.where(array < target_value)[0][-1]
 
 
 def make_spectrum_from_file(filename, units, path='', skiprows=0,


### PR DESCRIPTION
Hydrogen photoionization calculation fails on an off-by-one error when the nearest index to lambda_0 is > lambda_0 (causing epsilon to be sqrt(negative number) in the hydrogen photoionization cross section). The fix should ensure you're getting the closest index strictly less than lambda_0.