### PR TITLE
more exact photoionization calculation

### DIFF
--- a/p_winds/microphysics.py
+++ b/p_winds/microphysics.py
@@ -8,7 +8,7 @@ in the other modules.
 from __future__ import (division, print_function, absolute_import,
                         unicode_literals)
 import numpy as np
-
+import astropy.units as u
 from warnings import warn
 
 
@@ -66,6 +66,43 @@ def hydrogen_cross_section(wavelength=None, energy=None):
     else:
         raise ValueError('Either the wavelength or energy has to be provided.')
 
+def helium_total_cross_section(wavelength):
+    """
+    Compute the total photoionization cross-section of helium in function of
+    wavelength.
+
+    Source: Yan, Sadeghpour, & Dalgarno (1998, ApJ)
+
+    Parameters
+    ----------
+    wavelength (``numpy.ndarray``):
+        Wavelength in unit of angstrom.
+
+    Returns
+    -------
+    a_lambda_1 (``numpy.ndarray``):
+        Cross-section in function of wavelength and in unit of cm ** 2.
+    """
+    
+    nu_init = (wavelength*u.AA).to(u.Hz, equivalencies = u.spectral())
+
+    threshold_energy = 24.58*u.eV
+    
+    nu = nu_init.to(u.eV, equivalencies = u.spectral())
+    
+    x = nu / threshold_energy
+    e_term = (nu / u.eV / 1000.)**(7/2)
+    
+    coefs = [-4.7416, 14.8200, -30.8678, 37.3584, -23.4585, 5.9133]
+    sum_term = 0.
+    for i, coef in enumerate(coefs):
+        sum_term += coef / x**((i+1)/2)
+    
+    num = 733 * u.barn
+    out = num.to(u.cm * u.cm)/e_term * (1 + sum_term)
+    out[nu < threshold_energy] = 0.*(u.cm**2)
+
+    return out.to(u.cm**2).value
 
 # Photoionization cross-section of helium singlet
 def helium_singlet_cross_section(wavelength):


### PR DESCRIPTION
The current version of the code uses the approximation in Equation (9) of Oklopcic & Hirata (2018), where the photoionization rate Phi_prime is approximated as the photoionization rate at null optical depth Phi multiplied by exp(-tau_0). While this approximation works well in the optically thin outer part of the outflow, I have found that it can overestimate the photoionization rate by a factor of several near the ionization front. Therefore I have written an exact version of the photoionization calculation which can be accessed in the top-level "ion_fraction" function by setting the argument "exact_phi = True". I have left it as False by default so it does not change code behavior, but the default could be updated in the future.