### PR TITLE
corrected parker wind for tidal gravity effect

### DIFF
--- a/p_winds/parker.py
+++ b/p_winds/parker.py
@@ -262,7 +262,7 @@ def structure_tidal(r, c_s, r_s, M_p, M_star, a):
         Constant speed of sound with associated unit (for instance u.km/u.s)
 
     r_s (``astropy.Quantity``):
-        Sonic radius with associated unit (for instance u.Msun). Note: ensure
+        Sonic radius with associated unit (for instance u.Rjup). Note: ensure
         that this is computed with radius_sonic_point_tidal. 
 
     M_p (``astropy.Quantity``):


### PR DESCRIPTION
Murray-Clay et al. (2009) describe how the tidal gravity term in the momentum equation for the outflow can be important, especially for getting the location of the sonic point right. In an in-prep paper I've shown how that term tends to be important for the outflows we consider in helium observations of close-in planets, especially when we're exploring large ranges in the thermosphere temperature. I've included two new functions in p-winds for computing the density and velocity profiles of the Parker wind while taking that term into account. 