### PR TITLE
A candidate fix for Issue #38: Absolute versus relative units for average mean molecular weight

### DIFF
--- a/docs/source/tidal_effects.ipynb
+++ b/docs/source/tidal_effects.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "# Roche lobe effects\n",
+    "# Tidal effects\n",
     "\n",
     "In this notebook we explore the Roche lobe effects in one-dimensional Parker wind models for exospheres of hot exoplanets. These effects were notably discussed in [Erkaev et al. (2007)](https://ui.adsabs.harvard.edu/abs/2007A%26A...472..329E/abstract), and were implemented in `p-winds` [version 1.3.0](https://github.com/ladsantos/p-winds/releases/tag/v1.3.0).\n",
     "\n",

--- a/p_winds/hydrogen.py
+++ b/p_winds/hydrogen.py
@@ -461,9 +461,10 @@ def ion_fraction(radius_profile, planet_radius, temperature, h_fraction,
 
     # Calculate the average mean molecular weight using Eq. A.3 from Lampón et
     # al. 2020
-    # This function expects absolute---not relative---velocity units
+    # This function expects absolute---not relative---units
     velocity_kmps = velocity * vs
-    mu_bar = parker.average_molecular_weight(f_r, radius_profile, velocity_kmps,
+    mu_bar = parker.average_molecular_weight(f_r, radius_profile*planet_radius,
+                                             velocity_kmps,
                                              planet_mass, temperature,
                                              he_h_fraction)
 
@@ -514,7 +515,8 @@ def ion_fraction(radius_profile, planet_radius, temperature, h_fraction,
 
             # Here we update the average mean molecular weight
             velocity_kmps = velocity * vs
-            mu_bar = parker.average_molecular_weight(f_r, radius_profile,
+            mu_bar = parker.average_molecular_weight(f_r,
+                                                     radius_profile*planet_radius,
                                                      velocity_kmps,
                                                      planet_mass, temperature,
                                                      he_h_fraction)

--- a/p_winds/hydrogen.py
+++ b/p_winds/hydrogen.py
@@ -348,10 +348,10 @@ def ion_fraction(radius_profile, planet_radius, temperature, h_fraction,
 
     # Photoionization rate at null optical depth at the distance of the planet
     # from the host star, in unit of 1 / s.
+    vs = parker.sound_speed(temperature, mean_molecular_weight_0)
+    rs = parker.radius_sonic_point_tidal(planet_mass, vs, star_mass,
+                                            semimajor_axis)
     if exact_phi and spectrum_at_planet is not None:
-        vs = parker.sound_speed(temperature, mean_molecular_weight_0)
-        rs = parker.radius_sonic_point_tidal(planet_mass, vs, star_mass,
-                                             semimajor_axis)
         rhos = parker.density_sonic_point(mass_loss_rate, rs, vs)
         _, rho_norm = parker.structure_tidal(
             radius_profile * planet_radius / rs, vs, rs, planet_mass,
@@ -461,7 +461,9 @@ def ion_fraction(radius_profile, planet_radius, temperature, h_fraction,
 
     # Calculate the average mean molecular weight using Eq. A.3 from Lampón et
     # al. 2020
-    mu_bar = parker.average_molecular_weight(f_r, radius_profile, velocity,
+    # This function expects absolute---not relative---velocity units
+    velocity_kmps = velocity * vs
+    mu_bar = parker.average_molecular_weight(f_r, radius_profile, velocity_kmps,
                                              planet_mass, temperature,
                                              he_h_fraction)
 
@@ -511,8 +513,9 @@ def ion_fraction(radius_profile, planet_radius, temperature, h_fraction,
                                    ' solution.')
 
             # Here we update the average mean molecular weight
+            velocity_kmps = velocity * vs
             mu_bar = parker.average_molecular_weight(f_r, radius_profile,
-                                                     velocity,
+                                                     velocity_kmps,
                                                      planet_mass, temperature,
                                                      he_h_fraction)
 

--- a/p_winds/hydrogen.py
+++ b/p_winds/hydrogen.py
@@ -461,10 +461,9 @@ def ion_fraction(radius_profile, planet_radius, temperature, h_fraction,
 
     # Calculate the average mean molecular weight using Eq. A.3 from Lampón et
     # al. 2020
-    # This function expects absolute---not relative---units
-    velocity_kmps = velocity * vs
-    mu_bar = parker.average_molecular_weight(f_r, radius_profile*planet_radius,
-                                             velocity_kmps,
+    mu_bar = parker.average_molecular_weight(f_r,
+                                             radius_profile * planet_radius,
+                                             velocity * vs,
                                              planet_mass, temperature,
                                              he_h_fraction)
 
@@ -514,12 +513,10 @@ def ion_fraction(radius_profile, planet_radius, temperature, h_fraction,
                                    ' solution.')
 
             # Here we update the average mean molecular weight
-            velocity_kmps = velocity * vs
-            mu_bar = parker.average_molecular_weight(f_r,
-                                                     radius_profile*planet_radius,
-                                                     velocity_kmps,
-                                                     planet_mass, temperature,
-                                                     he_h_fraction)
+            mu_bar = parker.average_molecular_weight(
+                f_r, radius_profile * planet_radius, velocity * vs, planet_mass,
+                temperature, he_h_fraction
+            )
 
             # Calculate the relative change of f_ion in the outer shell of the
             # atmosphere (where we expect the most important change)

--- a/tests/test_carbon.py
+++ b/tests/test_carbon.py
@@ -9,7 +9,7 @@ from p_winds import hydrogen, helium, tools, parker, carbon
 # HD 209458 b
 R_pl = (1.39 * u.jupiterRad).value
 M_pl = (0.73 * u.jupiterMass).value
-m_dot = (5E11 * u.g / u.s).value
+m_dot = (8E10 * u.g / u.s).value
 T_0 = (9E3 * u.K).value
 h_fraction = 0.90
 he_fraction = 1 - h_fraction
@@ -60,7 +60,8 @@ def test_ion_fraction():
                                           radius_sonic_point=rs,
                                           density_sonic_point=rhos,
                                           spectrum_at_planet=spectrum,
-                                          initial_f_c_ion=np.array([0.5, 0.0]),
+                                          initial_f_c_ion=np.array([0.0, 0.0]),
+                                          method='odeint',
                                           relax_solution=True)
 
     # Assert if all values of the fractions are between 0 and 1

--- a/tests/test_hydrogen.py
+++ b/tests/test_hydrogen.py
@@ -22,7 +22,7 @@ r = np.linspace(1, 15, 500)
 # function for HD 209458 b should produce a profile with an ion fraction of
 # approximately one near the planetary surface, and approximately 4E-4 in the
 # outer layers.
-def test_ion_fraction_spectrum(precision_threshold=1E-5):
+def test_ion_fraction_spectrum(precision_threshold=1E-4):
     units = {'wavelength': u.angstrom, 'flux': u.erg / u.s / u.cm ** 2 /
                                                u.angstrom}
     spectrum = tools.make_spectrum_from_file(data_test_url, units)
@@ -32,11 +32,11 @@ def test_ion_fraction_spectrum(precision_threshold=1E-5):
                                 average_f_ion,
                                 spectrum_at_planet=spectrum,
                                 relax_solution=True)
-    assert abs((f_r[-1] - 0.998842) / f_r[-1]) < precision_threshold
+    assert abs((f_r[-1] - 0.998737) / f_r[-1]) < precision_threshold
 
     # Test the exact photoionization
     f_r = hydrogen.ion_fraction(r, R_pl, T_0, h_fraction, m_dot, M_pl,
                                 average_f_ion,
                                 spectrum_at_planet=spectrum,
                                 relax_solution=True, exact_phi=True)
-    assert abs((f_r[-1] - 0.998997) / f_r[-1]) < precision_threshold
+    assert abs((f_r[-1] - 0.998913) / f_r[-1]) < precision_threshold


### PR DESCRIPTION
Issue #38 points out that `average_molecular_weight` expects absolute flux units (km/s), but instead is being fed relative flux units in the `ion_fraction` function of `hydrogen.py`.  

Here we resolve that incongruence by multiplying the velocity by the sound speed before passing it into `average_molecular_weight`.

One tests isn't passing, due to a hardcoded reference value for an ion fraction.  That reference value may have been calculated with the previous inaccurate unit, so we should probably update the test with a new reference value or design a different test.