### PR TITLE
first version of Balmer implementation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
   given-names: "Shreyas"
   orcid: "https://orcid.org/0000-0003-2527-1475"
 title: "p-winds"
-version: 1.4.6
+version: 1.4.7
 doi: 10.1051/0004-6361/202142038
 date-released: 2021-12-21
 url: "https://github.com/ladsantos/p-winds"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # p-winds
 
-[![Documentation Status](https://readthedocs.org/projects/p-winds/badge/?version=latest)](https://p-winds.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://travis-ci.com/ladsantos/p-winds.svg?branch=main)](https://travis-ci.com/github/ladsantos/p-winds)  [![arXiv](https://img.shields.io/badge/arXiv-2111.11370-b31b1b.svg)](https://arxiv.org/abs/2111.11370)
+[![Documentation Status](https://readthedocs.org/projects/p-winds/badge/?version=latest)](https://p-winds.readthedocs.io/en/latest/?badge=latest) [![Build Status](https://app.travis-ci.com/ladsantos/p-winds.svg?token=dQGc2JwA9auSxvuCg1bH&branch=main)](https://travis-ci.com/github/ladsantos/p-winds)  [![arXiv](https://img.shields.io/badge/arXiv-2111.11370-b31b1b.svg)](https://arxiv.org/abs/2111.11370)
  [![Code DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4551621.svg)](https://doi.org/10.5281/zenodo.4551621)
 
 Python implementation of Parker wind models for planetary atmospheres. `p-winds` produces simplified, 1-D models of the upper atmosphere of a planet, and perform radiative transfer to calculate observable spectral signatures. 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2024, Leonardo A. dos Santos'
 author = 'Leonardo A. dos Santos'
 
 # The full version, including alpha/beta/rc tags
-release = 'v1.4.6'
+release = 'v1.4.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/quickstart.ipynb
+++ b/docs/source/quickstart.ipynb
@@ -514,9 +514,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/p_winds/carbon.py
+++ b/p_winds/carbon.py
@@ -10,7 +10,7 @@ from __future__ import (division, print_function, absolute_import,
 import numpy as np
 import astropy.units as u
 import astropy.constants as c
-from scipy.integrate import simps, solve_ivp, odeint
+from scipy.integrate import simpson, solve_ivp, odeint
 from p_winds import tools, microphysics
 import warnings
 
@@ -101,32 +101,32 @@ def radiative_processes(spectrum_at_planet):
                                                       species='C II')
 
     # The flux-averaged photoionization cross-section of C I and C II
-    a_ci = abs(simps(flux_lambda_cut_1 * a_lambda_ci, wavelength_cut_1) /
-               simps(flux_lambda_cut_1, wavelength_cut_1))
-    a_cii = abs(simps(flux_lambda_cut_2 * a_lambda_cii, wavelength_cut_2) /
-                simps(flux_lambda_cut_2, wavelength_cut_2))
+    a_ci = abs(simpson(flux_lambda_cut_1 * a_lambda_ci, wavelength_cut_1) /
+               simpson(flux_lambda_cut_1, wavelength_cut_1))
+    a_cii = abs(simpson(flux_lambda_cut_2 * a_lambda_cii, wavelength_cut_2) /
+                simpson(flux_lambda_cut_2, wavelength_cut_2))
 
     # The flux-averaged photoionization cross-section of H is also going to be
     # needed because it adds to the optical depth that C I and C II see.
     a_lambda_h_ci = microphysics.hydrogen_cross_section(
         wavelength=wavelength_cut_1)
-    a_h_ci = abs(simps(flux_lambda_cut_1 * a_lambda_h_ci, wavelength_cut_1) /
-                 simps(flux_lambda_cut_1, wavelength_cut_1))
+    a_h_ci = abs(simpson(flux_lambda_cut_1 * a_lambda_h_ci, wavelength_cut_1) /
+                 simpson(flux_lambda_cut_1, wavelength_cut_1))
     a_lambda_h_cii = microphysics.hydrogen_cross_section(
         wavelength=wavelength_cut_2)
-    a_h_cii = abs(simps(flux_lambda_cut_2 * a_lambda_h_cii, wavelength_cut_2) /
-                  simps(flux_lambda_cut_2, wavelength_cut_2))
+    a_h_cii = abs(simpson(flux_lambda_cut_2 * a_lambda_h_cii, wavelength_cut_2) /
+                  simpson(flux_lambda_cut_2, wavelength_cut_2))
 
     # Same for the He atoms, but only up to the He ionization threshold
     a_lambda_he = microphysics.helium_total_cross_section(wavelength_cut_0)
-    a_he = abs(simps(flux_lambda_cut_0 * a_lambda_he, wavelength_cut_0) /
-               simps(flux_lambda_cut_0, wavelength_cut_0))
+    a_he = abs(simpson(flux_lambda_cut_0 * a_lambda_he, wavelength_cut_0) /
+               simpson(flux_lambda_cut_0, wavelength_cut_0))
 
     # Calculate the photoionization rates
-    phi_ci = abs(simps(flux_lambda_cut_1 * a_lambda_ci / energy_cut_1,
+    phi_ci = abs(simpson(flux_lambda_cut_1 * a_lambda_ci / energy_cut_1,
                  wavelength_cut_1))
-    phi_cii = abs(simps(flux_lambda_cut_2 * a_lambda_cii / energy_cut_2,
-                        wavelength_cut_2))
+    phi_cii = abs(simpson(flux_lambda_cut_2 * a_lambda_cii / energy_cut_2,
+                          wavelength_cut_2))
 
     return phi_ci, phi_cii, a_ci, a_cii, a_h_ci, a_h_cii, a_he
 

--- a/p_winds/carbon.py
+++ b/p_winds/carbon.py
@@ -101,32 +101,32 @@ def radiative_processes(spectrum_at_planet):
                                                       species='C II')
 
     # The flux-averaged photoionization cross-section of C I and C II
-    a_ci = abs(simpson(flux_lambda_cut_1 * a_lambda_ci, wavelength_cut_1) /
-               simpson(flux_lambda_cut_1, wavelength_cut_1))
-    a_cii = abs(simpson(flux_lambda_cut_2 * a_lambda_cii, wavelength_cut_2) /
-                simpson(flux_lambda_cut_2, wavelength_cut_2))
+    a_ci = abs(simpson(flux_lambda_cut_1 * a_lambda_ci, x=wavelength_cut_1) /
+               simpson(flux_lambda_cut_1, x=wavelength_cut_1))
+    a_cii = abs(simpson(flux_lambda_cut_2 * a_lambda_cii, x=wavelength_cut_2) /
+                simpson(flux_lambda_cut_2, x=wavelength_cut_2))
 
     # The flux-averaged photoionization cross-section of H is also going to be
     # needed because it adds to the optical depth that C I and C II see.
     a_lambda_h_ci = microphysics.hydrogen_cross_section(
         wavelength=wavelength_cut_1)
-    a_h_ci = abs(simpson(flux_lambda_cut_1 * a_lambda_h_ci, wavelength_cut_1) /
-                 simpson(flux_lambda_cut_1, wavelength_cut_1))
+    a_h_ci = abs(simpson(flux_lambda_cut_1 * a_lambda_h_ci, x=wavelength_cut_1) /
+                 simpson(flux_lambda_cut_1, x=wavelength_cut_1))
     a_lambda_h_cii = microphysics.hydrogen_cross_section(
         wavelength=wavelength_cut_2)
-    a_h_cii = abs(simpson(flux_lambda_cut_2 * a_lambda_h_cii, wavelength_cut_2) /
-                  simpson(flux_lambda_cut_2, wavelength_cut_2))
+    a_h_cii = abs(simpson(flux_lambda_cut_2 * a_lambda_h_cii, x=wavelength_cut_2) /
+                  simpson(flux_lambda_cut_2, x=wavelength_cut_2))
 
     # Same for the He atoms, but only up to the He ionization threshold
     a_lambda_he = microphysics.helium_total_cross_section(wavelength_cut_0)
-    a_he = abs(simpson(flux_lambda_cut_0 * a_lambda_he, wavelength_cut_0) /
-               simpson(flux_lambda_cut_0, wavelength_cut_0))
+    a_he = abs(simpson(flux_lambda_cut_0 * a_lambda_he, x=wavelength_cut_0) /
+               simpson(flux_lambda_cut_0, x=wavelength_cut_0))
 
     # Calculate the photoionization rates
     phi_ci = abs(simpson(flux_lambda_cut_1 * a_lambda_ci / energy_cut_1,
-                 wavelength_cut_1))
+                 x=wavelength_cut_1))
     phi_cii = abs(simpson(flux_lambda_cut_2 * a_lambda_cii / energy_cut_2,
-                          wavelength_cut_2))
+                          x=wavelength_cut_2))
 
     return phi_ci, phi_cii, a_ci, a_cii, a_h_ci, a_h_cii, a_he
 

--- a/p_winds/energetics.py
+++ b/p_winds/energetics.py
@@ -10,7 +10,7 @@ from __future__ import (division, print_function, absolute_import,
 import numpy as np
 import astropy.units as u
 import astropy.constants as c
-from scipy.integrate import simps, cumtrapz
+from scipy.integrate import simpson, cumulative_trapezoid
 from scipy.interpolate import interp1d
 
 
@@ -146,7 +146,7 @@ def calculate_epsilon_max(r_grid, spectrum, n_h, n_he, n_he_plus, R_pl,
     r = r_grid.to(u.cm)
     integrand = total_heating_coef * r ** 2
     mask = (r >= R_pl) & (r <= R_roche)
-    eps = simps(integrand[mask], x=r[mask]) * u.cm ** 2 / (R_pl.to(u.cm) ** 2)
+    eps = simpson(integrand[mask], x=r[mask]) * u.cm ** 2 / (R_pl.to(u.cm) ** 2)
     return eps
 
 
@@ -203,7 +203,7 @@ def spec_av_cross(r_grid, spectrum, t_coef, species):
 
     numgrid = eta_grid * spec_grid * crossgrid * t_coef
     numgrid = numgrid.to(u.erg / u.s / u.Hz)
-    num = simps(numgrid, x=wavs_hz, axis=-1) * u.erg/u.s
+    num = simpson(numgrid, x=wavs_hz, axis=-1) * u.erg/u.s
 
     F_XUV = calculate_f_xuv(spectrum)
     cross = num / F_XUV
@@ -251,9 +251,9 @@ def compute_column_densities(r_grid, n_h, n_he, n_he_plus):
     n_he_temp = n_he[::-1]
     n_he_plus_temp = n_he_plus[::-1]
     
-    column_h = cumtrapz(n_h_temp, r_grid_temp, initial=0) * u.cm ** -2
-    column_he = cumtrapz(n_he_temp, r_grid_temp, initial=0) * u.cm ** -2
-    column_he_plus = cumtrapz(n_he_plus_temp, r_grid_temp,
+    column_h = cumulative_trapezoid(n_h_temp, r_grid_temp, initial=0) * u.cm ** -2
+    column_he = cumulative_trapezoid(n_he_temp, r_grid_temp, initial=0) * u.cm ** -2
+    column_he_plus = cumulative_trapezoid(n_he_plus_temp, r_grid_temp,
                               initial=0) * u.cm ** -2
     
     # Flip back
@@ -391,7 +391,7 @@ def calculate_f_xuv(spectrum):
                              equivalencies=u.spectral_density(wav_grid))
     wavs_hz = wav_grid.to(u.Hz, equivalencies=u.spectral())[::-1]
     flux_grid = flux_grid[::-1]
-    f_xuv = simps(flux_grid, x=wavs_hz) * u.erg / u.s / u.cm ** 2
+    f_xuv = simpson(flux_grid, x=wavs_hz) * u.erg / u.s / u.cm ** 2
     return f_xuv
 
 

--- a/p_winds/helium.py
+++ b/p_winds/helium.py
@@ -10,7 +10,7 @@ from __future__ import (division, print_function, absolute_import,
 import numpy as np
 import astropy.units as u
 import astropy.constants as c
-from scipy.integrate import simps, solve_ivp, odeint
+from scipy.integrate import simpson, solve_ivp, odeint
 from p_winds import tools, microphysics
 import warnings
 
@@ -125,10 +125,10 @@ def radiative_processes(spectrum_at_planet, combined_ionization=False):
         # may yield negative results when the flux varies by a few orders of
         # magnitude at the edges of integration. So we take the absolute values
         # of a_1 and a_3 here.
-        a_1 = abs(simps(flux_lambda_cut_1 * a_lambda_1, wavelength_cut_1) /
-                  simps(flux_lambda_cut_1, wavelength_cut_1))
-        a_3 = abs(simps(flux_lambda_cut_3 * a_lambda_3, wavelength_cut_3) /
-                  simps(flux_lambda_cut_3, wavelength_cut_3))
+        a_1 = abs(simpson(flux_lambda_cut_1 * a_lambda_1, wavelength_cut_1) /
+                  simpson(flux_lambda_cut_1, wavelength_cut_1))
+        a_3 = abs(simpson(flux_lambda_cut_3 * a_lambda_3, wavelength_cut_3) /
+                  simpson(flux_lambda_cut_3, wavelength_cut_3))
 
         # The flux-averaged photoionization cross-section of H is also going to
         # be needed because it adds to the optical depth that the He atoms see.
@@ -139,16 +139,16 @@ def radiative_processes(spectrum_at_planet, combined_ionization=False):
         # Contribution to the optical depth seen by He singlet atoms:
         # Note: the same ``scipy.integrate.simps`` behavior may happen here, so
         # again we take the absolute values of a_h_n and phi_n
-        a_h_1 = abs(simps(flux_lambda_cut_1 * a_lambda_h_1, wavelength_cut_1) /
-                    simps(flux_lambda_cut_1, wavelength_cut_1))
+        a_h_1 = abs(simpson(flux_lambda_cut_1 * a_lambda_h_1, wavelength_cut_1) /
+                    simpson(flux_lambda_cut_1, wavelength_cut_1))
         # Contribution to the optical depth seen by He triplet atoms:
-        a_h_3 = abs(simps(flux_lambda_cut_0 * a_lambda_h_3, wavelength_cut_0) /
-                    simps(flux_lambda_cut_3, wavelength_cut_3))
+        a_h_3 = abs(simpson(flux_lambda_cut_0 * a_lambda_h_3, wavelength_cut_0) /
+                    simpson(flux_lambda_cut_3, wavelength_cut_3))
 
         # Calculate the photoionization rates
-        phi_1 = abs(simps(flux_lambda_cut_1 * a_lambda_1 / energy_cut_1,
+        phi_1 = abs(simpson(flux_lambda_cut_1 * a_lambda_1 / energy_cut_1,
                     wavelength_cut_1))
-        phi_3 = abs(simps(flux_lambda_cut_3 * a_lambda_3 / energy_cut_3,
+        phi_3 = abs(simpson(flux_lambda_cut_3 * a_lambda_3 / energy_cut_3,
                     wavelength_cut_3))
 
         return phi_1, phi_3, a_1, a_3, a_h_1, a_h_3
@@ -160,18 +160,18 @@ def radiative_processes(spectrum_at_planet, combined_ionization=False):
         a_lambda = microphysics.helium_total_cross_section(wavelength_cut_1)
 
         # Flux-averaged photoionization cross-sections of He
-        a_he = abs(simps(flux_lambda_cut_1 * a_lambda, wavelength_cut_1) /
-                   simps(flux_lambda_cut_1, wavelength_cut_1))
+        a_he = abs(simpson(flux_lambda_cut_1 * a_lambda, wavelength_cut_1) /
+                   simpson(flux_lambda_cut_1, wavelength_cut_1))
 
         # The flux-averaged photoionization cross-section of H is also going to
         # be needed because it adds to the optical depth that the He atoms see.
         a_lambda_h = microphysics.hydrogen_cross_section(
             wavelength=wavelength_cut_1)
-        a_h = abs(simps(flux_lambda_cut_1 * a_lambda_h, wavelength_cut_1) /
-                  simps(flux_lambda_cut_1, wavelength_cut_1))
+        a_h = abs(simpson(flux_lambda_cut_1 * a_lambda_h, wavelength_cut_1) /
+                  simpson(flux_lambda_cut_1, wavelength_cut_1))
 
         # Calculate the photoionization rates
-        phi = abs(simps(flux_lambda_cut_1 * a_lambda / energy_cut_1,
+        phi = abs(simpson(flux_lambda_cut_1 * a_lambda / energy_cut_1,
                         wavelength_cut_1))
 
         return phi, a_he, a_h

--- a/p_winds/helium.py
+++ b/p_winds/helium.py
@@ -125,10 +125,10 @@ def radiative_processes(spectrum_at_planet, combined_ionization=False):
         # may yield negative results when the flux varies by a few orders of
         # magnitude at the edges of integration. So we take the absolute values
         # of a_1 and a_3 here.
-        a_1 = abs(simpson(flux_lambda_cut_1 * a_lambda_1, wavelength_cut_1) /
-                  simpson(flux_lambda_cut_1, wavelength_cut_1))
-        a_3 = abs(simpson(flux_lambda_cut_3 * a_lambda_3, wavelength_cut_3) /
-                  simpson(flux_lambda_cut_3, wavelength_cut_3))
+        a_1 = abs(simpson(flux_lambda_cut_1 * a_lambda_1, x=wavelength_cut_1) /
+                  simpson(flux_lambda_cut_1, x=wavelength_cut_1))
+        a_3 = abs(simpson(flux_lambda_cut_3 * a_lambda_3, x=wavelength_cut_3) /
+                  simpson(flux_lambda_cut_3, x=wavelength_cut_3))
 
         # The flux-averaged photoionization cross-section of H is also going to
         # be needed because it adds to the optical depth that the He atoms see.
@@ -139,17 +139,17 @@ def radiative_processes(spectrum_at_planet, combined_ionization=False):
         # Contribution to the optical depth seen by He singlet atoms:
         # Note: the same ``scipy.integrate.simps`` behavior may happen here, so
         # again we take the absolute values of a_h_n and phi_n
-        a_h_1 = abs(simpson(flux_lambda_cut_1 * a_lambda_h_1, wavelength_cut_1) /
-                    simpson(flux_lambda_cut_1, wavelength_cut_1))
+        a_h_1 = abs(simpson(flux_lambda_cut_1 * a_lambda_h_1, x=wavelength_cut_1) /
+                    simpson(flux_lambda_cut_1, x=wavelength_cut_1))
         # Contribution to the optical depth seen by He triplet atoms:
-        a_h_3 = abs(simpson(flux_lambda_cut_0 * a_lambda_h_3, wavelength_cut_0) /
-                    simpson(flux_lambda_cut_3, wavelength_cut_3))
+        a_h_3 = abs(simpson(flux_lambda_cut_0 * a_lambda_h_3, x=wavelength_cut_0) /
+                    simpson(flux_lambda_cut_3, x=wavelength_cut_3))
 
         # Calculate the photoionization rates
         phi_1 = abs(simpson(flux_lambda_cut_1 * a_lambda_1 / energy_cut_1,
-                    wavelength_cut_1))
+                    x=wavelength_cut_1))
         phi_3 = abs(simpson(flux_lambda_cut_3 * a_lambda_3 / energy_cut_3,
-                    wavelength_cut_3))
+                    x=wavelength_cut_3))
 
         return phi_1, phi_3, a_1, a_3, a_h_1, a_h_3
 
@@ -160,19 +160,19 @@ def radiative_processes(spectrum_at_planet, combined_ionization=False):
         a_lambda = microphysics.helium_total_cross_section(wavelength_cut_1)
 
         # Flux-averaged photoionization cross-sections of He
-        a_he = abs(simpson(flux_lambda_cut_1 * a_lambda, wavelength_cut_1) /
-                   simpson(flux_lambda_cut_1, wavelength_cut_1))
+        a_he = abs(simpson(flux_lambda_cut_1 * a_lambda, x=wavelength_cut_1) /
+                   simpson(flux_lambda_cut_1, x=wavelength_cut_1))
 
         # The flux-averaged photoionization cross-section of H is also going to
         # be needed because it adds to the optical depth that the He atoms see.
         a_lambda_h = microphysics.hydrogen_cross_section(
             wavelength=wavelength_cut_1)
-        a_h = abs(simpson(flux_lambda_cut_1 * a_lambda_h, wavelength_cut_1) /
-                  simpson(flux_lambda_cut_1, wavelength_cut_1))
+        a_h = abs(simpson(flux_lambda_cut_1 * a_lambda_h, x=wavelength_cut_1) /
+                  simpson(flux_lambda_cut_1, x=wavelength_cut_1))
 
         # Calculate the photoionization rates
         phi = abs(simpson(flux_lambda_cut_1 * a_lambda / energy_cut_1,
-                        wavelength_cut_1))
+                          x=wavelength_cut_1))
 
         return phi, a_he, a_h
 

--- a/p_winds/hydrogen.py
+++ b/p_winds/hydrogen.py
@@ -10,7 +10,7 @@ from __future__ import (division, print_function, absolute_import,
 import numpy as np
 import astropy.units as u
 import astropy.constants as c
-from scipy.integrate import simps, solve_ivp, cumtrapz
+from scipy.integrate import simpson, solve_ivp, cumulative_trapezoid
 from p_winds import parker, tools, microphysics
 
 
@@ -96,19 +96,19 @@ def radiative_processes_exact(spectrum_at_planet, r_grid, density, f_h_r,
         n_he = n_hetot * (1 - f_he_r)  # This is more correct
 
     n_h_temp = n_h[::-1]
-    column_h = cumtrapz(n_h_temp, r_grid_temp, initial=0)
+    column_h = cumulative_trapezoid(n_h_temp, r_grid_temp, initial=0)
     column_density_h = -column_h[::-1]
     tau_rnu = column_density_h[:, None] * a_lambda
 
     # Optical depth to helium photoionization
     n_he_temp = n_he[::-1]
-    column_he = cumtrapz(n_he_temp, r_grid_temp, initial=0)
+    column_he = cumulative_trapezoid(n_he_temp, r_grid_temp, initial=0)
     column_density_he = -column_he[::-1]
     a_lambda_he = microphysics.helium_total_cross_section(wavelength=xx)
     tau_rnu += column_density_he[:, None] * a_lambda_he
 
     # Finally calculate the photoionization rate
-    phi_prime = abs(simps(flux_lambda_cut * a_lambda / energy_cut *
+    phi_prime = abs(simpson(flux_lambda_cut * a_lambda / energy_cut *
                     np.exp(-tau_rnu), wavelength_cut, axis=-1))
 
     return phi_prime
@@ -160,11 +160,11 @@ def radiative_processes(spectrum_at_planet):
     # Note: For some reason the Simpson's rule implementation of ``scipy`` may
     # yield negative results when the flux varies by a few orders of magnitude
     # at the edges of integration. So we take the absolute values of a_0 and phi
-    a_0 = abs(simps(flux_lambda_cut * a_lambda, wavelength_cut) /
-              simps(flux_lambda_cut, wavelength_cut))
+    a_0 = abs(simpson(flux_lambda_cut * a_lambda, wavelength_cut) /
+              simpson(flux_lambda_cut, wavelength_cut))
 
     # Finally calculate the photoionization rate
-    phi = abs(simps(flux_lambda_cut * a_lambda / energy_cut, wavelength_cut))
+    phi = abs(simpson(flux_lambda_cut * a_lambda / energy_cut, wavelength_cut))
     return phi, a_0
 
 

--- a/p_winds/hydrogen.py
+++ b/p_winds/hydrogen.py
@@ -730,7 +730,7 @@ def halpha_scale(T_0,n_e, g_factor, n_shell):
     g_n = 2 * n_shell ** 2
     g_2 = 2 * 2 ** 2
     
-    n_H_2n_scale = g_shell * (frac_ground/g_2 - frac_n/g_n)
+    n_H_2n_scale = g_factor * (frac_ground/g_2 - frac_n/g_n)
 
     return n_H_2n_scale
 

--- a/p_winds/hydrogen.py
+++ b/p_winds/hydrogen.py
@@ -10,7 +10,7 @@ from __future__ import (division, print_function, absolute_import,
 import numpy as np
 import astropy.units as u
 import astropy.constants as c
-from scipy.integrate import simpson, solve_ivp, cumulative_trapezoid
+from scipy.integrate import simps, solve_ivp, cumtrapz
 from p_winds import parker, tools, microphysics
 
 
@@ -96,20 +96,20 @@ def radiative_processes_exact(spectrum_at_planet, r_grid, density, f_h_r,
         n_he = n_hetot * (1 - f_he_r)  # This is more correct
 
     n_h_temp = n_h[::-1]
-    column_h = cumulative_trapezoid(n_h_temp, r_grid_temp, initial=0)
+    column_h = cumtrapz(n_h_temp, r_grid_temp, initial=0)
     column_density_h = -column_h[::-1]
     tau_rnu = column_density_h[:, None] * a_lambda
 
     # Optical depth to helium photoionization
     n_he_temp = n_he[::-1]
-    column_he = cumulative_trapezoid(n_he_temp, r_grid_temp, initial=0)
+    column_he = cumtrapz(n_he_temp, r_grid_temp, initial=0)
     column_density_he = -column_he[::-1]
     a_lambda_he = microphysics.helium_total_cross_section(wavelength=xx)
     tau_rnu += column_density_he[:, None] * a_lambda_he
 
     # Finally calculate the photoionization rate
-    phi_prime = abs(simpson(y=flux_lambda_cut * a_lambda / energy_cut *
-                    np.exp(-tau_rnu), x=wavelength_cut, axis=-1))
+    phi_prime = abs(simps(flux_lambda_cut * a_lambda / energy_cut *
+                    np.exp(-tau_rnu), wavelength_cut, axis=-1))
 
     return phi_prime
 
@@ -160,12 +160,11 @@ def radiative_processes(spectrum_at_planet):
     # Note: For some reason the Simpson's rule implementation of ``scipy`` may
     # yield negative results when the flux varies by a few orders of magnitude
     # at the edges of integration. So we take the absolute values of a_0 and phi
-    a_0 = abs(simpson(flux_lambda_cut * a_lambda, x=wavelength_cut) /
-              simpson(flux_lambda_cut, x=wavelength_cut))
+    a_0 = abs(simps(flux_lambda_cut * a_lambda, wavelength_cut) /
+              simps(flux_lambda_cut, wavelength_cut))
 
     # Finally calculate the photoionization rate
-    phi = abs(simpson(flux_lambda_cut * a_lambda / energy_cut,
-                      x=wavelength_cut))
+    phi = abs(simps(flux_lambda_cut * a_lambda / energy_cut, wavelength_cut))
     return phi, a_0
 
 
@@ -571,3 +570,168 @@ def ion_fraction(radius_profile, planet_radius, temperature, h_fraction,
         return f_r, mu_bar, rates
     else:
         return f_r
+        
+def calc_boltzmann_distribution(T, n, NLTE_scaling = 1.):
+    """
+    Calculates the distribution of electronic states of the different atomic shells
+    of the hydrogen atom via the Boltzmann equation in LTE and NLTE.
+    In short, it calculates which fraction of the total number of H atoms are in the shell needed to produce H-alpha, H-beta etc lines.
+
+    Parameters
+    ----------
+    T: ``float``
+        Temperature in K
+    
+    n : ``integer``
+        For which shell number do we calculate the Boltzmann distribution
+
+    NLTE_scaling : ``float``
+        Default: 1. (LTE, no scaling)
+        If NLTE is assumed, the scaling factor can be a free fitting parameter in the retrieval on the data
+
+    Returns
+    -------
+    boltzmann_n : ``float``
+        Unitless fraction of Hydrogen population in the needed atomic shell for the specific Balmer-line
+
+    """
+        
+    # Energy of the nth state in the Balmer series as a difference to the ground state
+    #ground state energy for hydrogen is 13.6 eV
+    #E_n = E1 - E(n) in our case with E(n) = E1/n**2 for the Balmer series
+    E_n = 13.6 * (1-1/n**2) * u.eV
+    
+    # Population distribution via the Boltzmann equation
+    #This is the limit case for a large population of atoms as applicable in atmospheres
+    #Boltzmann_n = g_n/g_1 * np.exp(-E_n / (const.k_B * T))
+    #g_1 in our case is a constant and always 2
+    #g_n are the statistical weights of the electronic levels due to their degeneracies
+    #to generalise this function for other elements, simply let the user provide these as input, as well as the energy difference
+    g_n = 2.*n**2.
+    # Partition function for hydrogen
+    #is the sum over all quantum states for the atom where the electron could be, thus the sum over g_n*exp(-(E1-En)/(kb*T)
+    # in the case of hydrogen any contributions beyond n=2 are negligible
+    U_i = 2.*np.exp(-13.6 * u.eV / (c.k_B * T * u.K)) + 8.*np.exp(-13.6 * u.eV / (2**2 * c.k_B * T * u.K))
+    
+    #The NLTE scaling is defined as NLTE_scaling = Boltzmann_n (NLTE) / Boltzmann_n (LTE)
+    #from Barman et al. 2002 and others
+    #The scaling factor can be assumed as a constant for thermospheres
+    #from Huang et al. 2017, and Garcia Munoz and Schneider (2019)
+    
+    #calculate fraction of level population
+    
+    boltzmann_n = NLTE_scaling * (g_n/U_i) * np.exp(-E_n / (c.k_B * T * u.K)).decompose().value
+    
+
+    return boltzmann_n
+
+def calc_saha_distribution(T, electron_density):
+    """
+    Calculate the distribution of ionization states for the Balmer series of hydrogen
+    using the Saha equation.
+
+    Parameters
+    ----------
+    T: ``float``
+        Temperature in K
+        
+    electron_density: ``float``
+        the electron density (most likely coming from the background, but tbd). If only one level of ionisation is important then n1 = ne
+        The electron density has to have units of (cm**-3)
+    
+    n : ``integer``
+        Number of the atomic shell
+
+    Returns
+    -------
+    saha_n : ``float``
+        Unitless fraction of ionised Hydrogen from total Hydrogen for the specific Balmer-line
+    """
+
+    
+    # Boltzmann constant in eV/K
+#    k_B = c.k_B.to(u.eV / u.K)
+
+    # Ionization potential of hydrogen (eV)
+    ionization_potential = 13.6 * u.eV
+
+    # Partition function for hydrogen
+    #is the sum over all quantum states for the atom where the electron could be, thus the sum over g_n*exp(-(E1-En)/(kb*T)
+    # in the case of hydrogen any contributions beyond n=2 are negligible
+    U_i = 0.5 #ZII = 1 and ZI = g1 = 2
+    
+    #thermal deBroglie wavelength ** (-1)
+    debroglie_rev = np.sqrt(2 * np.pi * c.m_e * c.k_B * T * u.K / (c.h**2))
+
+    # Population distribution
+    #in reality the equation is not divided by U_i but multliplied by U_i(H II)/U_i(H I)
+    #For the Balmer series, H II is the naked proton core, as hydrogen only has one electron. Therefore, U_i(H II) = 1
+    saha_n = 2./(electron_density * U_i )* (debroglie_rev)**(3) * np.exp(-ionization_potential / (c.k_B * T * u.K))
+  
+    return saha_n
+    
+def relation_boltzmann_saha(T, n, electron_density, NLTE_scaling = 1.):
+    """
+    Calculates the fraction with relation to the total number of atoms taking into account Boltzmann and Saha
+
+    Parameters
+    ----------
+    T: ``float``
+        Temperature in K
+        
+    electron_density: ``float``
+        the electron density (most likely coming from the background, but tbd). If only one level of ionisation is important then n1 = ne
+        The electron density has to have units of (cm**-3)
+    
+    n : ``integer``
+        Number of the atomic shell
+
+    Returns
+    -------
+    total_fraction : ``float``
+        Unitless fraction of available Hydrogen from total Hydrogen for the specific Balmer-line
+    """
+
+    boltzmann_frac = calc_boltzmann_distribution(T, n, NLTE_scaling)
+    saha_frac = calc_saha_distribution(T, electron_density)
+    #relates the boltzmann and saha distribution together via the total number of hydrogen atoms
+    total_fraction = boltzmann_frac/((1+boltzmann_frac)*(1+saha_frac)) #1+boltzmann_frac_base+boltzmann_frac)*
+    return total_fraction
+    
+def halpha_scale(T_0,n_e, g_factor, n_shell):
+    """
+    Calculates the scaling factor of the hydrogen density for the Balmer lines after Wyttenbach et al. 2020 eq. 9
+
+    Parameters
+    ----------
+    T_0: ``float``
+        Temperature in K
+        
+    n_e: ``float``
+        the electron density (most likely coming from the background, but tbd). If only one level of ionisation is important then n1 = ne
+        The electron density has to have units of (cm**-3)
+        
+    g_factor: ''float''
+        the g scaling factor of the line in question from lines.py
+    
+    n_shell : ``integer``
+        Number of the atomic shell
+
+    Returns
+    -------
+        n_H_2n_scale : ``float``
+        Unitless fraction to adjust the hydrogen density for the specific Balmer-line
+    """
+
+    frac_n = relation_boltzmann_saha(T_0, n_shell, n_e)
+
+    frac_ground = relation_boltzmann_saha(T_0, 2, n_e)
+    
+    g_n = 2 * n_shell ** 2
+    g_2 = 2 * 2 ** 2
+    
+    n_H_2n_scale = g_shell * (frac_ground/g_2 - frac_n/g_n)
+
+    return n_H_2n_scale
+
+

--- a/p_winds/hydrogen.py
+++ b/p_winds/hydrogen.py
@@ -108,8 +108,8 @@ def radiative_processes_exact(spectrum_at_planet, r_grid, density, f_h_r,
     tau_rnu += column_density_he[:, None] * a_lambda_he
 
     # Finally calculate the photoionization rate
-    phi_prime = abs(simpson(flux_lambda_cut * a_lambda / energy_cut *
-                    np.exp(-tau_rnu), wavelength_cut, axis=-1))
+    phi_prime = abs(simpson(y=flux_lambda_cut * a_lambda / energy_cut *
+                    np.exp(-tau_rnu), x=wavelength_cut, axis=-1))
 
     return phi_prime
 
@@ -160,11 +160,12 @@ def radiative_processes(spectrum_at_planet):
     # Note: For some reason the Simpson's rule implementation of ``scipy`` may
     # yield negative results when the flux varies by a few orders of magnitude
     # at the edges of integration. So we take the absolute values of a_0 and phi
-    a_0 = abs(simpson(flux_lambda_cut * a_lambda, wavelength_cut) /
-              simpson(flux_lambda_cut, wavelength_cut))
+    a_0 = abs(simpson(flux_lambda_cut * a_lambda, x=wavelength_cut) /
+              simpson(flux_lambda_cut, x=wavelength_cut))
 
     # Finally calculate the photoionization rate
-    phi = abs(simpson(flux_lambda_cut * a_lambda / energy_cut, wavelength_cut))
+    phi = abs(simpson(flux_lambda_cut * a_lambda / energy_cut,
+                      x=wavelength_cut))
     return phi, a_0
 
 

--- a/p_winds/lines.py
+++ b/p_winds/lines.py
@@ -6,7 +6,7 @@ escape detection.
 """
 
 
-__all__ = ["he_3_properties", "c_ii_properties", "o_i_properties"]
+__all__ = ["he_3_properties", "c_ii_properties", "o_i_properties", "balmer_halpha_properties", "balmer_hbeta_properties", "balmer_hgamma_properties"]
 
 
 # Line properties of the 1.083 microns He triplet taken from the NIST database
@@ -161,3 +161,134 @@ def o_i_properties():
     a_ij_2 = 6.76e+07
 
     return lambda_0, lambda_1, lambda_2, f_0, f_1, f_2, a_ij_0, a_ij_1, a_ij_2
+
+
+# Line properties of the Balmer series lines (alpha, beta, gamma) taken from the NIST
+# database https://www.nist.gov/pml/atomic-spectra-database
+def balmer_halpha_properties():
+    """
+    Returns the central wavelengths in air, shell number and the
+    Einstein coefficient of the Balmer lines. The
+    values were taken from the NIST database:
+    https://www.nist.gov/pml/atomic-spectra-database
+
+    Returns
+    -------
+    lambda_alpha : ``float``
+        Central wavelength in air of the H-alpha line in unit of m.
+
+    n_alpha : ``integer``
+        Shell number creating the H-alpha line (unitless).
+        
+    f_alpha : ``float``
+        Oscillator strength (unitless).
+    
+    g_alpha : ``float``
+        log10(g2f2n_alpha) taking into account the oscillator strength (f2n)
+        and the statistical weight (g2) of the H-alpha line (unitless).
+
+    a_alpha : ``float``
+        Einstein coefficient of the H-alpha line in unit of 1 / s.
+
+    """
+    # Central wavelengths in units of m
+    lambda_alpha = 6562.79 * 1E-10
+    
+    #shell number
+    n_alpha = 3
+    
+    #oscillator strength
+    f_alpha = 6.4108e-01
+    
+    #statistical weight
+    g_alpha = 10**(0.71)
+    
+    # Einstein coefficient in units of s ** (-1)
+    a_alpha = 4.4101e+07
+
+
+    return lambda_alpha, n_alpha, f_alpha, g_alpha, a_alpha
+
+def balmer_hbeta_properties():
+    """
+    Returns the central wavelengths in air, shell number and the
+    Einstein coefficient of the Balmer lines. The
+    values were taken from the NIST database:
+    https://www.nist.gov/pml/atomic-spectra-database
+
+    Returns
+    -------
+    lambda_beta : ``float``
+        Central wavelength in air of the H-beta line in unit of m.
+
+    n_beta : ``integer``
+        Shell number creating the H-beta line (unitless).
+    
+    f_beta : ``float``
+        Oscillator strength (unitless).
+    
+    g_beta : ``float``
+        log10(g2f2n_alpha) taking into account the oscillator strength (f2n)
+        and the statistical weight (g2) of the H-beta line (unitless).
+        
+    a_beta : ``float``
+        Einstein coefficient of the H-beta line in unit of 1 / s.
+    """
+    # Central wavelengths in units of m
+    lambda_beta = 4861.35 * 1E-10
+
+    # Oscillator strength
+    f_beta = 1.1938e-01
+    
+    #shell number
+    n_beta = 4
+    
+    #statistical weight
+    g_beta= 10**(-0.02)
+    
+    # Einstein coefficient in units of s ** (-1)
+    a_beta = 8.4193e+06
+
+    return lambda_beta, n_beta, f_beta, g_beta,  a_beta
+
+def balmer_hgamma_properties():
+    """
+    Returns the central wavelengths in air, shell number and the
+    Einstein coefficient of the Balmer lines. The
+    values were taken from the NIST database:
+    https://www.nist.gov/pml/atomic-spectra-database
+
+    Returns
+    -------
+    lambda_gamma : ``float``
+        Central wavelength in air of the H-gamma line in unit of m.
+
+    n_gamma : ``integer``
+        Shell number creating the H-gamma line (unitless).
+        
+    f_gamma : ``float``
+        Oscillator strength (unitless).
+        
+    g_gamma : ``float``
+        log10(g2f2n_alpha) taking into account the oscillator strength (f2n)
+        and the statistical weight (g2) of the H-gamma line (unitless).
+
+    a_gamma : ``float``
+        Einstein coefficient of the H-gamma line in unit of 1 / s.
+    """
+    # Central wavelengths in units of m
+    lambda_gamma = 4340.47 * 1E-10
+    
+    #shell number
+    n_gamma = 5
+    
+    # Oscillator strength
+    f_gamma = 4.4694e-02
+    
+    #statistical weight
+    g_gamma = 10**(-0.447)
+    
+    # Einstein coefficient in units of s ** (-1)
+    a_gamma = 2.5304e+06
+
+    return lambda_gamma, n_gamma, f_gamma, g_gamma, a_gamma

--- a/p_winds/microphysics.py
+++ b/p_winds/microphysics.py
@@ -20,7 +20,7 @@ filterwarnings(action='ignore', category=RuntimeWarning)
 __all__ = ["hydrogen_cross_section", "helium_total_cross_section",
            "helium_singlet_cross_section", "helium_triplet_cross_section",
            "he_collisional_strength", "general_cross_section",
-           "sigma_properties_v1996", "collisional_excitation"]
+           "sigma_properties_v1996"]
 
 
 # Photoionization cross-section of hydrogen

--- a/p_winds/oxygen.py
+++ b/p_winds/oxygen.py
@@ -10,7 +10,7 @@ from __future__ import (division, print_function, absolute_import,
 import numpy as np
 import astropy.units as u
 import astropy.constants as c
-from scipy.integrate import simps, solve_ivp, odeint
+from scipy.integrate import simpson, solve_ivp, odeint
 from p_winds import tools, microphysics
 import warnings
 
@@ -80,24 +80,24 @@ def radiative_processes(spectrum_at_planet):
                                                      species='O I')
 
     # The flux-averaged photoionization cross-section of O I
-    a_oi = abs(simps(flux_lambda_cut_1 * a_lambda_oi, wavelength_cut_1) /
-               simps(flux_lambda_cut_1, wavelength_cut_1))
+    a_oi = abs(simpson(flux_lambda_cut_1 * a_lambda_oi, wavelength_cut_1) /
+               simpson(flux_lambda_cut_1, wavelength_cut_1))
 
     # The flux-averaged photoionization cross-section of H is also going to be
     # needed because it adds to the optical depth that O I see.
     a_lambda_h_oi = microphysics.hydrogen_cross_section(
         wavelength=wavelength_cut_1)
-    a_h_oi = abs(simps(flux_lambda_cut_1 * a_lambda_h_oi, wavelength_cut_1) /
-                 simps(flux_lambda_cut_1, wavelength_cut_1))
+    a_h_oi = abs(simpson(flux_lambda_cut_1 * a_lambda_h_oi, wavelength_cut_1) /
+                 simpson(flux_lambda_cut_1, wavelength_cut_1))
 
     # Same for the He atoms, but only up to the He ionization threshold
     a_lambda_he = microphysics.helium_total_cross_section(wavelength_cut_0)
-    a_he = abs(simps(flux_lambda_cut_0 * a_lambda_he, wavelength_cut_0) /
-               simps(flux_lambda_cut_0, wavelength_cut_0))
+    a_he = abs(simpson(flux_lambda_cut_0 * a_lambda_he, wavelength_cut_0) /
+               simpson(flux_lambda_cut_0, wavelength_cut_0))
 
     # Calculate the photoionization rates
-    phi_oi = abs(simps(flux_lambda_cut_1 * a_lambda_oi / energy_cut_1,
-                       wavelength_cut_1))
+    phi_oi = abs(simpson(flux_lambda_cut_1 * a_lambda_oi / energy_cut_1,
+                         wavelength_cut_1))
 
     return phi_oi, a_oi, a_h_oi, a_he
 

--- a/p_winds/oxygen.py
+++ b/p_winds/oxygen.py
@@ -80,24 +80,24 @@ def radiative_processes(spectrum_at_planet):
                                                      species='O I')
 
     # The flux-averaged photoionization cross-section of O I
-    a_oi = abs(simpson(flux_lambda_cut_1 * a_lambda_oi, wavelength_cut_1) /
-               simpson(flux_lambda_cut_1, wavelength_cut_1))
+    a_oi = abs(simpson(flux_lambda_cut_1 * a_lambda_oi, x=wavelength_cut_1) /
+               simpson(flux_lambda_cut_1, x=wavelength_cut_1))
 
     # The flux-averaged photoionization cross-section of H is also going to be
     # needed because it adds to the optical depth that O I see.
     a_lambda_h_oi = microphysics.hydrogen_cross_section(
         wavelength=wavelength_cut_1)
-    a_h_oi = abs(simpson(flux_lambda_cut_1 * a_lambda_h_oi, wavelength_cut_1) /
-                 simpson(flux_lambda_cut_1, wavelength_cut_1))
+    a_h_oi = abs(simpson(flux_lambda_cut_1 * a_lambda_h_oi, x=wavelength_cut_1) /
+                 simpson(flux_lambda_cut_1, x=wavelength_cut_1))
 
     # Same for the He atoms, but only up to the He ionization threshold
     a_lambda_he = microphysics.helium_total_cross_section(wavelength_cut_0)
-    a_he = abs(simpson(flux_lambda_cut_0 * a_lambda_he, wavelength_cut_0) /
-               simpson(flux_lambda_cut_0, wavelength_cut_0))
+    a_he = abs(simpson(flux_lambda_cut_0 * a_lambda_he, x=wavelength_cut_0) /
+               simpson(flux_lambda_cut_0, x=wavelength_cut_0))
 
     # Calculate the photoionization rates
     phi_oi = abs(simpson(flux_lambda_cut_1 * a_lambda_oi / energy_cut_1,
-                         wavelength_cut_1))
+                         x=wavelength_cut_1))
 
     return phi_oi, a_oi, a_h_oi, a_he
 

--- a/p_winds/parker.py
+++ b/p_winds/parker.py
@@ -8,7 +8,7 @@ from __future__ import (division, print_function, absolute_import,
                         unicode_literals)
 import numpy as np
 import scipy.optimize as so
-from scipy.integrate import simps, trapz
+from scipy.integrate import simpson, trapezoid
 from astropy import units as u, constants as c
 
 __all__ = ["average_molecular_weight", "sound_speed", "radius_sonic_point",
@@ -66,11 +66,11 @@ def average_molecular_weight(ion_fraction_profile, r_profile, v_profile,
 
     # Eq. A.3 of Lampón et al. 2020 is a combination of several integrals, which
     # we calculate here
-    int_1 = simps(mu_r / r ** 2, r)
-    int_2 = simps(mu_r * v_r, v_r)
-    int_3 = trapz(mu_r, 1 / mu_r)
-    int_4 = simps(1 / r ** 2, r)
-    int_5 = simps(v_r, v_r)
+    int_1 = simpson(mu_r / r ** 2, r)
+    int_2 = simpson(mu_r * v_r, v_r)
+    int_3 = trapezoid(mu_r, 1 / mu_r)
+    int_4 = simpson(1 / r ** 2, r)
+    int_5 = simpson(v_r, v_r)
     int_6 = 1 / mu_r[-1] - 1 / mu_r[0]
     term_1 = grav * m_planet * int_1 + int_2 + k_b * temperature * int_3
     term_2 = grav * m_planet * int_4 + int_5 + k_b * temperature * int_6

--- a/p_winds/parker.py
+++ b/p_winds/parker.py
@@ -66,11 +66,11 @@ def average_molecular_weight(ion_fraction_profile, r_profile, v_profile,
 
     # Eq. A.3 of Lampón et al. 2020 is a combination of several integrals, which
     # we calculate here
-    int_1 = simpson(mu_r / r ** 2, r)
-    int_2 = simpson(mu_r * v_r, v_r)
+    int_1 = simpson(mu_r / r ** 2, x=r)
+    int_2 = simpson(mu_r * v_r, x=v_r)
     int_3 = trapezoid(mu_r, 1 / mu_r)
-    int_4 = simpson(1 / r ** 2, r)
-    int_5 = simpson(v_r, v_r)
+    int_4 = simpson(1 / r ** 2, x=r)
+    int_5 = simpson(v_r, x=v_r)
     int_6 = 1 / mu_r[-1] - 1 / mu_r[0]
     term_1 = grav * m_planet * int_1 + int_2 + k_b * temperature * int_3
     term_2 = grav * m_planet * int_4 + int_5 + k_b * temperature * int_6

--- a/p_winds/tools.py
+++ b/p_winds/tools.py
@@ -16,7 +16,7 @@ from astropy.io import fits
 __all__ = ["nearest_index", "standard_spectrum", "generate_muscles_spectrum",
            "make_spectrum_from_file"]
 
-# Find $MUSCLES_DIR environment variable
+# Find $PWINDS_REFSPEC_DIR environment variable
 try:
     _PWINDS_REFSPEC_DIR = os.environ["PWINDS_REFSPEC_DIR"]
 except KeyError:

--- a/p_winds/tools.py
+++ b/p_winds/tools.py
@@ -68,6 +68,7 @@ def standard_spectrum(stellar_type, semi_major_axis,
     ----------
     stellar_type : ``str``
         Define the stellar type. The available options are:
+
         - ``'mid-A'`` (based on HR 8799)
         - ``'early-F'`` (based on WASP-17)
         - ``'late-F'`` (based on HD 108147)

--- a/p_winds/transit.py
+++ b/p_winds/transit.py
@@ -169,8 +169,9 @@ def radiative_transfer_2d(intensity_0, r_from_planet, radius_profile,
     wavelength_grid : ``numpy.ndarray``
         Wavelengths to calculate the profile in unit of m.
 
-    gas_temperature : ``float``
-        Gas temperature in K.
+    gas_temperature : ``float`` or ``numpy.ndarray``
+        1-D profile of temperatures in function of radius. Unit has to be K. If
+        defined as ``float``, then the model assumes isothermal gas.
 
     particle_mass : ``float``
         Mass of the particle corresponding to the transition in unit of kg.
@@ -230,7 +231,8 @@ def radiative_transfer_2d(intensity_0, r_from_planet, radius_profile,
 
 
 # Density and velocity profiles in the line of sight
-def profile_los(radius_profile, density_profile, velocity_profile, z_grid_size):
+def profile_los(radius_profile, density_profile, velocity_profile,
+                z_grid_size, temperature_profile=None):
     """
     Calculate the profiles of radius and line-of-sight velocities in function of
     sky-projected radial distance from the planet (axis 0) and the line of sight
@@ -252,6 +254,11 @@ def profile_los(radius_profile, density_profile, velocity_profile, z_grid_size):
 
     z_grid_size : ``int``, optional
         Grid size for the line of sight direction.
+
+    temperature_profile : ``numpy.ndarray``, optional
+        1-D profile of temperatures in function of radius, in whatever unit you
+        want to work with. If ``None``, then the code assumes isothermal
+        temperature. Default is ``None``.
 
     Returns
     -------
@@ -288,7 +295,16 @@ def profile_los(radius_profile, density_profile, velocity_profile, z_grid_size):
                    fill_value=0.0)
     los_density_r_z = d_v(distances)
 
-    return los_density_r_z, los_velocity_r_z, los_z
+    if temperature_profile is not None:
+        # Calculate the line-of-sight temperature
+        t_v = interp1d(radius_profile, temperature_profile, bounds_error=False,
+                       fill_value=0.0)
+        los_temperature_r_z = t_v(distances)
+
+        return los_density_r_z, los_velocity_r_z, los_temperature_r_z, los_z
+
+    else:
+        return los_density_r_z, los_velocity_r_z, los_z
 
 
 # Optical depth in function of cylindrical radius from the planet and
@@ -336,13 +352,14 @@ def optical_depth_2d(radius_profile, density_profile, velocity_profile,
     wavelength_grid : ``numpy.ndarray``
         Wavelengths to calculate the profile in unit of m.
 
-    gas_temperature : ``float``
-        Gas temperature in K.
+    gas_temperature : ``float`` or ``numpy.ndarray``
+        1-D profile of temperatures in function of radius. Unit has to be K. If
+        defined as ``float``, then the model assumes isothermal gas.
 
     particle_mass : ``float``
         Mass of the particle corresponding to the transition in unit of kg.
 
-    z_grid_size : ``int``, optional
+    z_grid_size : ``int``
         Grid size for the line of sight direction.
 
     bulk_los_velocity : ``float``, optional
@@ -373,11 +390,23 @@ def optical_depth_2d(radius_profile, density_profile, velocity_profile,
         Optical depth in function of radial distance from the center of the
         planet (axis 0) and in function of wavelength (axis 1).
     """
-    # Calculate density and velocity profiles in the line of sight
-    density_los, velocity_los, z_los = \
-        profile_los(radius_profile, density_profile, velocity_profile,
-                    z_grid_size)
-    spatial_shape = np.shape(density_los)
+    # Calculate density, velocity profiles and, if necessary, temperature
+    # profile in the line of sight
+    if isinstance(gas_temperature, float) or isinstance(gas_temperature, int):
+        density_los, velocity_los, z_los = \
+            profile_los(radius_profile, density_profile, velocity_profile,
+                        z_grid_size)
+        spatial_shape = np.shape(density_los)
+        temp = gas_temperature
+    elif isinstance(gas_temperature, np.ndarray):
+        density_los, velocity_los, temperature_los, z_los = \
+            profile_los(radius_profile, density_profile, velocity_profile,
+                        z_grid_size=z_grid_size,
+                        temperature_profile=gas_temperature)
+        temp = temperature_los
+    else:
+        raise ValueError('`gas_temperature` has to be either `float` or '
+                         '`np.ndarray`.')
 
     # Spectral line properties
     w0 = central_wavelength  # Reference wavelength in m
@@ -409,7 +438,6 @@ def optical_depth_2d(radius_profile, density_profile, velocity_profile,
     nu_grid_rest = c_speed / wl_grid
     v_bulk = bulk_los_velocity
     rv_planet = planet_radial_velocity
-    temp = gas_temperature
     mass = particle_mass
 
     # Change the shape of `nu_grid_rest` to allow for proper array broadcasting
@@ -453,15 +481,20 @@ def optical_depth_2d(radius_profile, density_profile, velocity_profile,
                 (np.sum(velocity_los ** 2 * weights) /
                  np.sum(weights)) ** 0.5
 
+            if isinstance(temp, np.ndarray):
+                average_temp = np.sum(temp * weights) / np.sum(weights)
+            elif isinstance(temp, float) or isinstance(temp, int):
+                average_temp = temp
+
             if turbulence_broadening is True:
                 # Similar to Lampon et al. (2020), calculate the broadening
                 # as the turbulent velocity = sqrt(5/3 * kT / m)
-                turbulence_velocity = np.sqrt(5 / 3 * k_b * temp / mass)
+                turbulence_velocity = np.sqrt(5 / 3 * k_b * average_temp / mass)
             else:
                 turbulence_velocity = 0.0
 
             # Calculate Doppler width of the Voigt profile
-            alpha_nu = nu0_k / c_speed * (2 * k_b * temp / mass +
+            alpha_nu = nu0_k / c_speed * (2 * k_b * average_temp / mass +
                                           wind_broadening_velocity ** 2 +
                                           turbulence_velocity ** 2) ** 0.5
 

--- a/p_winds/transit.py
+++ b/p_winds/transit.py
@@ -462,7 +462,7 @@ def optical_depth_2d(radius_profile, density_profile, velocity_profile,
         if _method == 'formal':
             # Calculate Doppler width (standard deviation) of the Voigt profile
             alpha_nu = \
-                nu0_k / c_speed * (2 * k_b * temp / mass) ** 0.5
+                nu0_k / c_speed * (k_b * temp / mass) ** 0.5
 
             # Calculate the frequency shifts due to wind and bulk motion
             delta_nu_wind = (velocity_los + v_bulk +
@@ -488,13 +488,13 @@ def optical_depth_2d(radius_profile, density_profile, velocity_profile,
 
             if turbulence_broadening is True:
                 # Similar to Lampon et al. (2020), calculate the broadening
-                # as the turbulent velocity = sqrt(5/3 * kT / m)
-                turbulence_velocity = np.sqrt(5 / 3 * k_b * average_temp / mass)
+                # as the turbulent velocity = sqrt(5/3 * kT / 2m)
+                turbulence_velocity = np.sqrt(5 / 6 * k_b * average_temp / mass)
             else:
                 turbulence_velocity = 0.0
 
             # Calculate Doppler width of the Voigt profile
-            alpha_nu = nu0_k / c_speed * (2 * k_b * average_temp / mass +
+            alpha_nu = nu0_k / c_speed * (k_b * average_temp / mass +
                                           wind_broadening_velocity ** 2 +
                                           turbulence_velocity ** 2) ** 0.5
 

--- a/p_winds/transit.py
+++ b/p_winds/transit.py
@@ -8,7 +8,7 @@ planets and atmospheres.
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.special import voigt_profile
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 from flatstar import draw, utils
 
 
@@ -513,7 +513,7 @@ def optical_depth_2d(radius_profile, density_profile, velocity_profile,
         # Calculate the optical depths divided by the cross section
         density_expanded = np.expand_dims(density_los, axis=-1)
         opt_depth_over_cross_section_r_nu = \
-            trapz(profiles * density_expanded, z_los, axis=0)
+            trapezoid(profiles * density_expanded, z_los, axis=0)
 
         return opt_depth_over_cross_section_r_nu
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.argv[-1] == "publish":
 
 setup(
     name="p_winds",
-    version="1.4.6",
+    version="1.4.7",
     author="Leonardo dos Santos",
     author_email="ldsantos@stsci.edu",
     packages=["p_winds"],


### PR DESCRIPTION
In this module is the first draft of the implementation of p-winds for the Balmer alpha, beta, and gamma lines via Boltzmann distribution and Saha equation. The calculation of the opacity follows Wyttenbach et al. (2020).

Questions that need to be addressed from this commit before it is usable:
 -How do we calculate the electron density?
-How do we integrate this model via the Voigt profile into p-winds' main framework?
-How to we link the calculated opacity to the LOS calculation in p-winds
-Will we retrieve each Balmer line separately? And if we combined the fit, how do we address the difference in continuum between the Balmer lines?