### PR TITLE
Perf: Factor out spatially constant voigt profile in avg mode

### DIFF
--- a/p_winds/transit.py
+++ b/p_winds/transit.py
@@ -588,11 +588,23 @@ def optical_depth_2d(radius_profile, density_profile, velocity_profile,
             raise ValueError('The chosen voigt_method is not implemented.')
 
         profiles = 0.5 * profiles_morn + 0.5 * profiles_even
+        # `profiles` dimensions by wind broadening method:
+        # 'average': (n_wavelengths,)
+        # 'formal': (n_z, n_radii, n_wavelengths)
 
         # Calculate the optical depths divided by the cross section
-        density_expanded = np.expand_dims(density_los, axis=-1)
-        opt_depth_over_cross_section_r_nu = \
-            trapezoid(profiles * density_expanded, z_los, axis=0)
+        profile_is_spatially_constant = profiles.ndim == 1
+        # Keep empty integrals on the direct path: zero * NaN would give NaN.
+        if profile_is_spatially_constant and z_los.size > 1:
+            # True in 'average' mode. We can factor the profile out of the
+            # integral over z.
+            column_density = trapezoid(density_los, z_los, axis=0)
+            opt_depth_over_cross_section_r_nu = \
+                column_density[:, None] * profiles
+        else:
+            density_expanded = np.expand_dims(density_los, axis=-1)
+            opt_depth_over_cross_section_r_nu = \
+                trapezoid(profiles * density_expanded, z_los, axis=0)
 
         return opt_depth_over_cross_section_r_nu
 

--- a/tests/test_transit.py
+++ b/tests/test_transit.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import pytest
 from p_winds import lines, transit
 
 
@@ -46,3 +47,17 @@ def test_draw_transit_and_radiative_transfer(precision_threshold=5E-3):
                                              wind_broadening_method='average')
     test_value_2 = spectrum[60]
     assert abs((test_value_2 - 0.97946) / test_value_2) < precision_threshold
+
+
+@pytest.mark.parametrize('z_grid_size', [0, 1, 23])
+def test_average_and_formal_optical_depth_agree_without_wind_broadening(z_grid_size):
+    radius = r[::25]
+    # With zero wind and uniform temperature, both methods use the same Voigt
+    # profile. Empty integrals must also agree, even if the average is undefined.
+    args = (radius, n_he_3[::25], np.zeros_like(radius), w_array, f_array,
+            a_array, wl[::10], t_0, m_He, z_grid_size)
+    with np.errstate(invalid='ignore'):
+        average = transit.optical_depth_2d(*args, wind_broadening_method='average')
+        formal = transit.optical_depth_2d(*args, wind_broadening_method='formal')
+    np.testing.assert_allclose(average, formal, rtol=1e-14, atol=0.0,
+                               equal_nan=False)


### PR DESCRIPTION
We can speed up `optical_depth_2d`'s `average` mode considerably by taking advantage of the fact that in average mode the voigt profile doesn't actually depend on `z` at all, so we can pull it out of the integral over `z`, reducing computational work and intermediate memory allocations.

Previously, `trapezoid` had to integrate over the full (Z, R, W) cube - runtime was roughly O(Z*R*W). Now we integrate over (Z, R) and then do one R*W outer product, so our asymptotic runtime is whichever of O(Z*R) and O(R*W) is greater.

Concretely, on my M3 mac, with 100 z samples, 100 radii, 129 wavelengths, three helium lines, and average wind broadening, `optical_depth_2d` goes from 14ms to 0.4ms, a 30x-ish speedup.

The numerics seem ok here, this isn't bitwise equivalent to the old way, which is to be expected - the max relative diff in this example below was 1.4e-15.

Here's a synthetic benchmarking example if you want to reproduce (thx gpt6 for writing it):

```python
from timeit import repeat
import numpy as np
from p_winds import lines, transit

n_z, n_radii, n_wavelengths = 100, 100, 129
radius = np.linspace(1e8, 1e9, n_radii)  # m
w0, w1, w2, f0, f1, f2, a_ij = lines.he_3_properties()
kwargs = dict(
    radius_profile=radius,
    density_profile=1e8 * (radius[0] / radius) ** 2,  # m^-3
    velocity_profile=np.full_like(radius, 1e4),  # m/s
    central_wavelength=[w0, w1, w2],
    oscillator_strength=[f0, f1, f2],
    einstein_coefficient=[a_ij] * 3,
    wavelength_grid=np.linspace(1.0827e-6, 1.0832e-6, n_wavelengths),
    gas_temperature=9000.0,  # K
    particle_mass=4 * 1.67262192369e-27,  # kg
    z_grid_size=n_z,
    wind_broadening_method='average',
    voigt_method='fast',
)

def run():
    return transit.optical_depth_2d(**kwargs)

print(f'Grid: z={n_z}, radii={n_radii}, wavelengths={n_wavelengths}')
tau = run()  # Warm up, including Numba compilation, before timing.
calls = 20
timings = repeat(run, number=calls, repeat=7)
print(f'Median: {np.median(timings) / calls * 1000:.3f} ms/call')
print(f'Optical depth: shape={tau.shape}, min={tau.min():.12g}, '
      f'max={tau.max():.12g}, sum={tau.sum():.12g}')
```

Before:
```
Grid: z=100, radii=100, wavelengths=129
Median: 14.223 ms/call
Optical depth: shape=(100, 129), min=0, max=2.13790683729, sum=850.311545918
```

After:
```
Grid: z=100, radii=100, wavelengths=129
Median: 0.484 ms/call
Optical depth: shape=(100, 129), min=0, max=2.13790683729, sum=850.311545918
```